### PR TITLE
fix bug undefined method when update custom fields

### DIFF
--- a/lib/hipchat_notifier.rb
+++ b/lib/hipchat_notifier.rb
@@ -2,6 +2,7 @@ module HipchatNotifier
   include Redmine::I18n
   include ActionView::Helpers::TagHelper
   include IssuesHelper
+  include CustomFieldsHelper
 
   def send_issue_reported_to_hipchat(issue)
     return unless @settings = get_settings(issue)


### PR DESCRIPTION
`show_detail` calls `format_value` in `CustomFieldHelper`.
However, `hipchat_norifier.rb` doesn't inherit `CustomFieldHelper`, So it is not found.
